### PR TITLE
Dockerfile build fix for Issue #20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV SRC_DIR=/go/src/github.com/ice3man543/subfinder/
 ADD . $SRC_DIR
 
 # Build it:
-RUN cd $SRC_DIR; go build -o main; cp main /app/
+RUN cd $SRC_DIR; go get; go build -o main; cp main /app/
 
 ENTRYPOINT ["./main"]
 CMD ["-h"]


### PR DESCRIPTION
Added missing go dependencies retrieval (Issue #20). This way the build executes correctly:

```
$ docker build -t subfinder .
Sending build context to Docker daemon  5.494MB
Step 1/7 : FROM iron/go:dev
dev: Pulling from iron/go
2595db787577: Pull complete 
25f4744d75f7: Pull complete 
e5c42b04f34b: Pull complete 
2c16999b2da4: Pull complete 
f07ddaf6c162: Pull complete 
bfac150e9ba1: Pull complete 
7c7bda04128a: Pull complete 
Digest: sha256:b80fdc916aec2ab0237bb434b0d9b022f8aabd8e161a7015aea496a90039ae1e
Status: Downloaded newer image for iron/go:dev
 ---> 04f0f1a5b78c
Step 2/7 : WORKDIR /app
Removing intermediate container 3a4439dc1fdc
 ---> 16b00ea15d53
Step 3/7 : ENV SRC_DIR=/go/src/github.com/ice3man543/subfinder/
 ---> Running in b0063b35d84e
Removing intermediate container b0063b35d84e
 ---> a3803fa3adb9
Step 4/7 : ADD . $SRC_DIR
 ---> 0c1cd027d2d4
Step 5/7 : RUN cd $SRC_DIR; go get; go build -o main; cp main /app/
 ---> Running in cd457da71f6d
Removing intermediate container cd457da71f6d
 ---> 78907de7c1be
Step 6/7 : ENTRYPOINT ["./main"]
 ---> Running in 66e305553c3b
Removing intermediate container 66e305553c3b
 ---> 9d6f15acecd6
Step 7/7 : CMD ["-h"]
 ---> Running in e72a290d5b70
Removing intermediate container e72a290d5b70
 ---> d0ddc79451df
Successfully built d0ddc79451df
Successfully tagged subfinder:latest
$ 
```