### PR TITLE
changed FROM iron/go:dev to golang for RPi support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # iron/go:dev is the alpine image with the go tools added
-FROM iron/go:dev
+FROM golang
 WORKDIR /app
 
 # Set an env var that matches your github repo name


### PR DESCRIPTION
Tested this on my Raspberry Pi 3 with Ubuntu 16.04 and it's working fine with this little change. 

Also tested it on my main OS (Fedora 27) and no issues occurred.

- x1m